### PR TITLE
Generic support for views params

### DIFF
--- a/DIOSView.m
+++ b/DIOSView.m
@@ -38,6 +38,11 @@
 @implementation DIOSView
 - (void)viewGet:(NSDictionary *)params success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
         failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error)) failure {
-  [[DIOSSession sharedSession] getPath:[NSString stringWithFormat:@"%@/%@/%@?display_id=%@&limit=%@&offset=%@%@", kDiosEndpoint, kDiosBaseView, [params objectForKey:@"view_name"], [params objectForKey:@"display_id"], [params objectForKey:@"limit"], [params objectForKey:@"offset"], [params objectForKey:@"other_params"]] parameters:nil success:success failure:failure];
+        NSMutableString *path = [NSMutableString stringWithFormat:@"%@/%@/%@?", kDiosEndpoint, kDiosBaseView, [params objectForKey:@"view_name"]];
+	for (NSString *key in params) {
+		id value = [params objectForKey:key];
+		[path appendFormat:@"%@=%@&", key, value];
+	}
+	[[DIOSSession sharedSession] getPath:path parameters:nil success:success failure:failure];
 }
 @end

--- a/DIOSView.m
+++ b/DIOSView.m
@@ -38,10 +38,12 @@
 @implementation DIOSView
 - (void)viewGet:(NSDictionary *)params success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
         failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error)) failure {
-        NSMutableString *path = [NSMutableString stringWithFormat:@"%@/%@/%@?", kDiosEndpoint, kDiosBaseView, [params objectForKey:@"view_name"]];
+	NSMutableString *path = [NSMutableString stringWithFormat:@"%@/%@/%@?", kDiosEndpoint, kDiosBaseView, [params objectForKey:@"view_name"]];
 	for (NSString *key in params) {
 		id value = [params objectForKey:key];
-		[path appendFormat:@"%@=%@&", key, value];
+		if (![key isEqualToString:@"view_name"]) {
+			[path appendFormat:@"%@=%@&", key, value];
+		}
 	}
 	[[DIOSSession sharedSession] getPath:path parameters:nil success:success failure:failure];
 }

--- a/DIOSView.m
+++ b/DIOSView.m
@@ -38,6 +38,6 @@
 @implementation DIOSView
 - (void)viewGet:(NSDictionary *)params success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
         failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error)) failure {
-  [[DIOSSession sharedSession] getPath:[NSString stringWithFormat:@"%@/%@/%@", kDiosEndpoint, kDiosBaseView, [params objectForKey:@"view_name"]] parameters:nil success:success failure:failure];
+  [[DIOSSession sharedSession] getPath:[NSString stringWithFormat:@"%@/%@/%@?display_id=%@&limit=%@&offset=%@%@", kDiosEndpoint, kDiosBaseView, [params objectForKey:@"view_name"], [params objectForKey:@"display_id"], [params objectForKey:@"limit"], [params objectForKey:@"offset"], [params objectForKey:@"other_params"]] parameters:nil success:success failure:failure];
 }
 @end

--- a/README.md
+++ b/README.md
@@ -2,78 +2,19 @@ Drupal iOS SDK - Connect your iOS/OS X app to Drupal
 ================================
 What you need to know
 ================================
-The Drupal iOS SDK is a standard set of libraries for communicating to Drupal from any iOS device. Its extremely simple.
-If you wanted to get a node you can do so by instantiating a DIOSNode Object, creating an 
-NSDictionairy and running the nodeGet method.  Heres an example:
+This fork has just a few differences with the forked branch.
 
-```obj-c
-    DIOSNode *node = [[DIOSNode alloc] init];
-    NSMutableDictionary *nodeData = [NSMutableDictionary new];
-    [nodeData setValue:@"12" forKey:@"nid"];
-    [node nodeGet:nodeData success:^(AFHTTPRequestOperation *operation, id responseObject) {
-      //Do Something with the responseObject
-      NSLog(@"%@", responseObject);
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-      //we failed, uh-oh lets error log this.
-      NSLog(@"%@,  %@", [error localizedDescription], [operation responseString]);    
-    }];
-    
-```
-For every DIOS Object you make, any method calls that are available to you use blocks. 
-This allows us to define what happens when we have a request that fails or succeeds. 
-If the request was successful the result would be something like this:
-
-    {"vid":"9","uid":"57","title":"testtitle","log":"","status":"1".......
-    
-However if it failed, the error might look like this:
-
-    Expected status code in (200-299), got 404,  "Node 5 could not be found"
-    
-What you need to get started
 ================================
-* This library :) 
-* AFNetwork which can be found [here](https://github.com/AFNetworking/AFNetworking)
-* Be sure to follow the AFNetworking installation guide.
-* Update Settings.h with the correct correct url and endpoints)
-* [Services](http://github.com/kylebrowning/services)
+Differences between original branch and this fork
+================================
 
-Demo App (Work in progress)
---------------------
-[http://github.com/workhabitinc/drupal-ios-sdk-example](http://github.com/workhabitinc/drupal-ios-sdk-example)
+    DIOSView *view = [[DIOSView alloc] init];
+	NSMutableDictionary *tempDict = [NSMutableDictionary new];
+    [tempDict setValue:@"users" forKey:@"view_name"];
+	[tempDict setValue:@"page_1" forKey:@"display_id"];
+	[tempDict setValue:@"20" forKey:@"limit"];
+	[tempDict setValue:@"10" forKey:@"offset"];
+	[tempDict setValue:@"&picture=1" forKey:@"other_params"];
 
-Branches
---------------------
-6.x-2.x 6.x-3.x and 7.x-3.x have all been moved to a  *DEPRECATED* version of their branch.
-The new dev branch will be the become the new master and as things are added, versions will be tagged and published.
-master will always be the latest and greatest for the most up to date version of everything(Services, Drupal, Services Api, DIOS).
-
-Tags are in this format
-`2.1-1.0` Which breaks down as, DIOSVersion 2.1, Services Api Version 1.0
-
-Branches are in this format
-`2.x-1.x`
-
-OAuth
---------------------
-its coming.
-
-
-Documentation
------------
-[Can be found here](https://github.com/workhabitinc/drupal-ios-sdk/wiki/drupal-ios-sdk-2.0)
-
-Troubleshooting
-----------
-If you are getting Access denied, or API Key not valid, double check that your key settings are setup correctly at admin/build/services/keys and double check that permissions are correct for your user and anonymous.
-
-X service doesnt exist in Drupal iOS SDK
-----------
-You no longer really need to subclass any existing DIOS classes, unless you want to override.
-`[DIOSSession shared]` ensures that session information is stored for as long as the cookies are valid
-If you do want to make your own object, just follow the pattern in the other files and everything should work fine.
-Use the issue queue here on github if you have questions.
-
-Questions
-----------
-Checkout the Issue queue, or email me
-Email kyle@workhabit.com
+This example loads the view "users" with display_id "page_1", shows "20" records starting at offset "10" and using the exposed filter "picture" to show only users with picture.
+To properly use "other_params" you have to add "&field_name=value" for each exposed filter you need to set.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,78 @@ Drupal iOS SDK - Connect your iOS/OS X app to Drupal
 ================================
 What you need to know
 ================================
-This fork has just a few differences with the forked branch.
+The Drupal iOS SDK is a standard set of libraries for communicating to Drupal from any iOS device. Its extremely simple.
+If you wanted to get a node you can do so by instantiating a DIOSNode Object, creating an 
+NSDictionairy and running the nodeGet method.  Heres an example:
 
+```obj-c
+    DIOSNode *node = [[DIOSNode alloc] init];
+    NSMutableDictionary *nodeData = [NSMutableDictionary new];
+    [nodeData setValue:@"12" forKey:@"nid"];
+    [node nodeGet:nodeData success:^(AFHTTPRequestOperation *operation, id responseObject) {
+      //Do Something with the responseObject
+      NSLog(@"%@", responseObject);
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+      //we failed, uh-oh lets error log this.
+      NSLog(@"%@,  %@", [error localizedDescription], [operation responseString]);    
+    }];
+    
+```
+For every DIOS Object you make, any method calls that are available to you use blocks. 
+This allows us to define what happens when we have a request that fails or succeeds. 
+If the request was successful the result would be something like this:
+
+    {"vid":"9","uid":"57","title":"testtitle","log":"","status":"1".......
+    
+However if it failed, the error might look like this:
+
+    Expected status code in (200-299), got 404,  "Node 5 could not be found"
+    
+What you need to get started
 ================================
-Differences between original branch and this fork
-================================
+* This library :) 
+* AFNetwork which can be found [here](https://github.com/AFNetworking/AFNetworking)
+* Be sure to follow the AFNetworking installation guide.
+* Update Settings.h with the correct correct url and endpoints)
+* [Services](http://github.com/kylebrowning/services)
 
-    DIOSView *view = [[DIOSView alloc] init];
-	NSMutableDictionary *tempDict = [NSMutableDictionary new];
-    [tempDict setValue:@"users" forKey:@"view_name"];
-	[tempDict setValue:@"page_1" forKey:@"display_id"];
-	[tempDict setValue:@"20" forKey:@"limit"];
-	[tempDict setValue:@"10" forKey:@"offset"];
-	[tempDict setValue:@"&picture=1" forKey:@"other_params"];
+Demo App (Work in progress)
+--------------------
+[http://github.com/workhabitinc/drupal-ios-sdk-example](http://github.com/workhabitinc/drupal-ios-sdk-example)
 
-This example loads the view "users" with display_id "page_1", shows "20" records starting at offset "10" and using the exposed filter "picture" to show only users with picture.
-To properly use "other_params" you have to add "&field_name=value" for each exposed filter you need to set.
+Branches
+--------------------
+6.x-2.x 6.x-3.x and 7.x-3.x have all been moved to a  *DEPRECATED* version of their branch.
+The new dev branch will be the become the new master and as things are added, versions will be tagged and published.
+master will always be the latest and greatest for the most up to date version of everything(Services, Drupal, Services Api, DIOS).
+
+Tags are in this format
+`2.1-1.0` Which breaks down as, DIOSVersion 2.1, Services Api Version 1.0
+
+Branches are in this format
+`2.x-1.x`
+
+OAuth
+--------------------
+its coming.
+
+
+Documentation
+-----------
+[Can be found here](https://github.com/workhabitinc/drupal-ios-sdk/wiki/drupal-ios-sdk-2.0)
+
+Troubleshooting
+----------
+If you are getting Access denied, or API Key not valid, double check that your key settings are setup correctly at admin/build/services/keys and double check that permissions are correct for your user and anonymous.
+
+X service doesnt exist in Drupal iOS SDK
+----------
+You no longer really need to subclass any existing DIOS classes, unless you want to override.
+`[DIOSSession shared]` ensures that session information is stored for as long as the cookies are valid
+If you do want to make your own object, just follow the pattern in the other files and everything should work fine.
+Use the issue queue here on github if you have questions.
+
+Questions
+----------
+Checkout the Issue queue, or email me
+Email kyle@workhabit.com


### PR DESCRIPTION
Added explicit support for display_id, limit, offset and generic support for any other parameter. "other_params" is useful when trying to filter out results with exposed filters (not contextual filters).
