### PR TITLE
Handles CSRF token changes

### DIFF
--- a/DIOSCSRFAFHTTPClient.m
+++ b/DIOSCSRFAFHTTPClient.m
@@ -13,14 +13,12 @@
 
 - (NSString*)getCSRFToken
 {
-    static NSString* csrfToken;
+    NSString* csrfToken;
     
-    if(!csrfToken) {
-        
-        NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@/services/session/token", kDiosBaseUrl]]];
-        NSData *data = [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:nil];
-        csrfToken = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    }
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@/services/session/token", kDiosBaseUrl]]];
+    NSData *data = [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:nil];
+    csrfToken = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    
     return csrfToken;
 }
 


### PR DESCRIPTION
CSRF Tokens change over time. They automatically change after login and logout. So having the csrf token string static works only for one login session. This has been changed, even tough it means for each put/post/delete, the token has to be queried.
