### PR TITLE
Removes setBaseURL Calls

### DIFF
--- a/DIOSSession.m
+++ b/DIOSSession.m
@@ -77,7 +77,6 @@ realm, signRequests, threeLegged;
     sharedSession = [[self alloc] initWithBaseURL:[NSURL URLWithString:url]];
     [sharedSession setParameterEncoding:AFJSONParameterEncoding];
   });
-  [sharedSession setBaseURL:[NSURL URLWithString:url]];
   return sharedSession;
 }
 
@@ -86,7 +85,6 @@ realm, signRequests, threeLegged;
     sharedSession = [[self alloc] initWithBaseURL:[NSURL URLWithString:url] consumerKey:aConsumerKey secret:aConsumerSecret];
     [sharedSession setParameterEncoding:AFJSONParameterEncoding];
   });
-  [sharedSession setBaseURL:[NSURL URLWithString:url]];
   return sharedSession;
 }
 


### PR DESCRIPTION
setBaseURL doesn't exist as a method and anyone trying to use this library has always (or at least as long I've been using it for the past year+) had to just comment out those lines in order to compile.  It seems like whatever was supposed to be accomplished with those lines is handled with the initWithBaseURL calls.
