### PR TITLE
CSRF Token Updates

### DIFF
--- a/DIOSSystem.m
+++ b/DIOSSystem.m
@@ -49,7 +49,6 @@
     DIOSSession *session = [DIOSSession sharedSession];
     [session getCSRFTokenWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         [[DIOSSession sharedSession] sendRequestWithPath:@"system/connect" method:@"POST" params:nil success:^(AFHTTPRequestOperation *operation, id responseObject) {
-            [[DIOSSession sharedSession] setCsrfToken:[responseObject objectForKey:@"token"]];
             [[DIOSSession sharedSession] setUser:[responseObject objectForKey:@"user"]];
             [[DIOSSession sharedSession] setSystemConnected:YES];
             if (success != nil) {

--- a/DIOSUser.m
+++ b/DIOSUser.m
@@ -135,7 +135,7 @@ static NSUInteger USERNAME_MAX_LENGTH = 60;
     
     [[DIOSSession sharedSession] sendRequestWithPath:path method:@"POST" params:params success:^(AFHTTPRequestOperation *operation, id responseObject) {
         [[DIOSSession sharedSession] setUser:[responseObject objectForKey:@"user"]];
-        [[DIOSSession sharedSession] setCsrfToken:[responseObject objectForKey:@"token"]];
+        [DIOSSession getCSRFToken]; // CSRF Token is based on session data. After login the session is changed. Forcing a new token to be retreived and saved.
         if (success != nil) {
             success(operation, responseObject);
         }


### PR DESCRIPTION
Issues with CSRF Tokens:
- No token send after connect. Setting with null will reset valid token.
- After login, a new token is required (CSRF Token is based on session data). Forcing a new token to be loaded after sign-in.
